### PR TITLE
fix: redundant memory store statements for static variables

### DIFF
--- a/ctowasm/src/processor/processDeclaration.ts
+++ b/ctowasm/src/processor/processDeclaration.ts
@@ -78,7 +78,8 @@ export function processLocalDeclaration(
 
     symbolEntry = symbolEntry as VariableSymbolEntry; // definitely not dealing with a function declaration already
 
-    if (typeof declaration.initializer !== "undefined") {
+    // We have already allocated space for data segment variables, no more memory statements are needed
+    if (typeof declaration.initializer !== "undefined" && symbolEntry.type !== "dataSegmentVariable") {
       return unpackLocalVariableInitializerAccordingToDataType(
         symbolEntry,
         declaration.initializer,


### PR DESCRIPTION
**Bug description :** 
Declaring static variables in the main function would result in _WASM memory access out of bounds error._
In sourceacademy playground it would show _index out of bounds_
**Sample code to reproduce the issue :**
```
int main() {
    static int g = 12;
}

```
**Root cause :**
Compiler consider local scope static variables as normal variables and write memory store statements for each static variable declaration and attempt to store the assigned values into _bp + address of that static variable_ which would result in out of bounds error in specific cases.
For instance, the example mentioned would have this line of code in WAT code which should not have been included in the code :
` (i32.store (i32.add (global.get $bp) (i32.const 0))`
0 is the address of the defined static variable.

**Solution :**
Adding condition in local declaration processes to pass data segment variable declarations for adding memory statements.

**Test cases:**
I already ran all the written test cases and all of them were passed.
