### PR TITLE
fix: support uppercase ‘L’ suffix in integer literals & correct float negation in WAT generator

### DIFF
--- a/ctowasm/src/parser/peggyjs/parser.pegjs
+++ b/ctowasm/src/parser/peggyjs/parser.pegjs
@@ -376,9 +376,9 @@
     let correctedSuffix;
     if (suffix.length > 0) {
       correctedSuffix = suffix.toLowerCase();
-      if (correctedSuffix.contains("ll")) {
+      if (correctedSuffix.includes("ll")) {
         // in this implementation long long and long are identical
-        if (correctedSuffix.contains("u")) {
+        if (correctedSuffix.includes("u")) {
           correctedSuffix = "ul";
         } else {
           correctedSuffix = "l";

--- a/ctowasm/src/wat-generator/generateWatExpression.ts
+++ b/ctowasm/src/wat-generator/generateWatExpression.ts
@@ -43,7 +43,7 @@ export default function generateWatExpression(node: WasmExpression): string {
   } else if (node.type === "NumericWrapper") {
     return `(${node.instruction} ${generateWatExpression(node.expr)})`;
   } else if (node.type === "NegateFloatExpression") {
-    return `(${node.wasmDataType}.neg ${node.expr})`;
+    return `(${node.wasmDataType}.neg ${generateWatExpression(node.expr)})`;
   } else if (node.type === "PostStatementExpression") {
     return `${generateWatExpression(node.expr)} ${generateStatementsList(
       node.statements,


### PR DESCRIPTION
Fix:

- suffixes "ll", "l", "ul", and their uppercase equivalents were not recognised. This PR fixes this.
- fixes the floating-point negation in the WAT generator.
