### PR TITLE
feat: added the modules sound and plotly, and compose_filter in pix_n_flix

### DIFF
--- a/ctowasm/src/modules/index.ts
+++ b/ctowasm/src/modules/index.ts
@@ -7,6 +7,14 @@ import {
   SourceStandardLibraryModule,
   sourceStandardLibraryModuleImportName,
 } from "~src/modules/source_stdlib";
+import {
+  SoundLibraryModule,
+  soundLibraryModuleImportName,
+} from "~src/modules/sound";
+import {
+  PlotlyLibraryModule,
+  plotlyLibraryModuleImportName,
+} from "~src/modules/plotly";
 import { Module } from "~src/modules/types";
 import { UtilityStdLibModule, utilityStdLibName } from "~src/modules/utility";
 import { WASM_ADDR_TYPE } from "~src/translator/memoryUtil";
@@ -31,7 +39,9 @@ export type ModuleName =
   | typeof sourceStandardLibraryModuleImportName
   | typeof pixAndFlixLibraryModuleImportName
   | typeof mathStdlibName
-  | typeof utilityStdLibName;
+  | typeof utilityStdLibName
+  | typeof soundLibraryModuleImportName
+  | typeof plotlyLibraryModuleImportName;
 
 /**
  * Holds all the modules that define functions that can be imported and used in C source program.
@@ -91,6 +101,18 @@ export default class ModuleRepository {
         this.sharedWasmGlobalVariables,
       ),
       [utilityStdLibName]: new UtilityStdLibModule(
+        this.memory,
+        this.functionTable,
+        this.config,
+        this.sharedWasmGlobalVariables,
+      ),
+      [soundLibraryModuleImportName]: new SoundLibraryModule(
+        this.memory,
+        this.functionTable,
+        this.config,
+        this.sharedWasmGlobalVariables,
+      ),
+      [plotlyLibraryModuleImportName]: new PlotlyLibraryModule(
         this.memory,
         this.functionTable,
         this.config,

--- a/ctowasm/src/modules/jsFunctionUtils.ts
+++ b/ctowasm/src/modules/jsFunctionUtils.ts
@@ -1,0 +1,233 @@
+import { WASM_ADDR_SIZE } from "~src/common/constants";
+import { SharedWasmGlobalVariables } from "~src/modules";
+
+/**
+ * Manually generates a WebAssembly binary for a function with the given signature.
+ * This creates a minimal module that imports a function with the specified signature
+ * and re-exports it.
+ * 
+ * @param paramTypes Array of parameter types ("i32", "i64", "f32", "f64")
+ * @param resultType Return type or null for void ("i32", "i64", "f32", "f64", null)
+ * @returns Base64 encoded WebAssembly binary
+ */
+function generateWasmBinary(paramTypes: string[], resultType: string | null): string {
+  // WebAssembly binary format constants
+  const WASM_BINARY_MAGIC = [0x00, 0x61, 0x73, 0x6D]; // \0asm
+  const WASM_BINARY_VERSION = [0x01, 0x00, 0x00, 0x00]; // version 1
+  
+  // Section IDs
+  const TYPE_SECTION_ID = 0x01;
+  const IMPORT_SECTION_ID = 0x02;
+  const FUNCTION_SECTION_ID = 0x03;
+  const EXPORT_SECTION_ID = 0x07;
+  
+  // Value types
+  const TYPE_MAP: Record<string, number> = {
+    "i32": 0x7F,
+    "i64": 0x7E,
+    "f32": 0x7D,
+    "f64": 0x7C,
+  };
+  
+  // Function type form
+  const FUNC_TYPE_FORM = 0x60;
+  
+  // Create binary array
+  let binary: number[] = [
+    ...WASM_BINARY_MAGIC,
+    ...WASM_BINARY_VERSION
+  ];
+  
+  // TYPE SECTION - Define function signature
+  const typeSection: number[] = [
+    TYPE_SECTION_ID, // section ID
+    0x00, // section size placeholder
+    0x01, // number of types
+    FUNC_TYPE_FORM, // function type
+    paramTypes.length, // number of parameters
+  ];
+  
+  // Add parameter types
+  for (const param of paramTypes) {
+    typeSection.push(TYPE_MAP[param]);
+  }
+  
+  // Add result type
+  if (resultType === null) {
+    typeSection.push(0x00); // no results
+  } else {
+    typeSection.push(0x01); // one result
+    typeSection.push(TYPE_MAP[resultType]);
+  }
+  
+  // Fix type section size
+  typeSection[1] = typeSection.length - 2; // -2 for the section ID and size bytes
+  
+  // IMPORT SECTION - Import the function from module "m", name "f"
+  const importSection: number[] = [
+    IMPORT_SECTION_ID, // section ID
+    0x00, // section size placeholder
+    0x01, // number of imports
+    0x01, // length of module name
+    0x6D, // "m"
+    0x01, // length of field name
+    0x66, // "f"
+    0x00, // import kind (function)
+    0x00, // function type index
+  ];
+  
+  // Fix import section size
+  importSection[1] = importSection.length - 2; // -2 for the section ID and size bytes
+  
+  // FUNCTION SECTION - (Empty for this simple case)
+  
+  // EXPORT SECTION - Export the imported function as "f"
+  const exportSection: number[] = [
+    EXPORT_SECTION_ID, // section ID
+    0x00, // section size placeholder
+    0x01, // number of exports
+    0x01, // length of export name
+    0x66, // "f"
+    0x00, // export kind (function)
+    0x00, // function index
+  ];
+  
+  // Fix export section size
+  exportSection[1] = exportSection.length - 2; // -2 for the section ID and size bytes
+  
+  // Combine all sections
+  binary = [
+    ...binary,
+    ...typeSection,
+    ...importSection,
+    ...exportSection
+  ];
+  
+  return btoa(String.fromCharCode(...binary));
+}
+
+/**
+ * Adds a JavaScript function with custom parameter and return types to the WebAssembly function table.
+ * 
+ * @param jsFunction JavaScript function to add to the table
+ * @param paramTypes Array of parameter types (e.g., ["f64", "i32"])
+ * @param resultType Return type or null for void 
+ * @param functionTable The WebAssembly function table
+ * @param memory WebAssembly memory
+ * @param sharedWasmGlobalVariables Global variables for stack/base pointers
+ * @returns Index of the function in the table
+ */
+export function addCustomJsFunctionToTable(
+    jsFunction: (...args: any[]) => any,
+    paramTypes: string[],
+    resultType: string | null,
+    functionTable: WebAssembly.Table,
+    memory: WebAssembly.Memory,
+    sharedWasmGlobalVariables: SharedWasmGlobalVariables
+  ): number {
+    // Create wrapper that reads parameters from memory based on types
+    const stackWrapperFunc = (...dummyArgs: any[]) => {
+      // Read parameters from stack - in reverse order to match WebAssembly calling convention
+      const args: any[] = [];
+      const reversedParamTypes = [...paramTypes].reverse(); // Create a reversed copy
+      
+      // Calculate starting offset
+      let currentOffset = sharedWasmGlobalVariables.stackPointer.value;
+      
+      // First determine the total size needed for all parameters to find starting point
+      // of the last parameter (which is first in WebAssembly stack)
+      let totalSize = 0;
+      for (const paramType of paramTypes) {
+        switch (paramType) {
+          case "i32":
+          case "f32":
+            totalSize += 4;
+            break;
+          case "i64":
+          case "f64":
+            totalSize += 8;
+            break;
+        }
+      }
+      
+      let readOffset = currentOffset;
+      
+      // Read parameters in reverse order and build args array in correct order
+      const tempArgs: any[] = [];
+      
+      for (const paramType of reversedParamTypes) {
+        const dataView = new DataView(memory.buffer, readOffset);
+        let value: any;
+        
+        switch (paramType) {
+          case "i32":
+            value = dataView.getInt32(0, true);
+            readOffset += 4;
+            break;
+          case "i64":
+            value = dataView.getBigInt64(0, true);
+            readOffset += 8;
+            break;
+          case "f32":
+            value = dataView.getFloat32(0, true);
+            readOffset += 4;
+            break;
+          case "f64":
+            value = dataView.getFloat64(0, true);
+            readOffset += 8;
+            break;
+        }
+        
+        tempArgs.push(value);
+      }
+      
+      // Reverse thordere collected arguments to get them in the original 
+      args.push(...tempArgs.reverse());
+      
+      const result = jsFunction(...args);
+      
+      // Write result to memory if needed
+      if (resultType !== null) {
+        const returnOffset = sharedWasmGlobalVariables.basePointer.value + WASM_ADDR_SIZE;
+        const returnView = new DataView(memory.buffer, returnOffset);
+        
+        switch (resultType) {
+          case "i32":
+            returnView.setInt32(0, Number(result), true);
+            break;
+          case "i64":
+            returnView.setBigInt64(0, BigInt(result), true);
+            break;
+          case "f32":
+            returnView.setFloat32(0, Number(result), true);
+            break;
+          case "f64":
+            returnView.setFloat64(0, Number(result), true);
+            break;
+        }
+      }
+      
+      return 0;
+    };
+    
+    const base64BinaryString = generateWasmBinary(paramTypes, resultType);
+    
+    try {
+      const binary = new Uint8Array(atob(base64BinaryString).split("").map((c) => c.charCodeAt(0)));
+      
+      const instance = new WebAssembly.Instance(new WebAssembly.Module(binary), {
+        m: { f: stackWrapperFunc }
+      });
+      
+      const wasmFunction = instance.exports.f;
+      
+      const newFuncPtr = functionTable.length;
+      functionTable.grow(1);
+      functionTable.set(newFuncPtr, wasmFunction);
+      
+      return newFuncPtr;
+    } catch (e) {
+      console.error("Error adding custom function to WebAssembly table:", e);
+      throw e;
+    }
+  }

--- a/ctowasm/src/modules/memoryArrayAccessorUtils.ts
+++ b/ctowasm/src/modules/memoryArrayAccessorUtils.ts
@@ -1,0 +1,368 @@
+/**
+ * Type definition for memory field descriptors with automatic offset calculation
+ */
+export type MemoryFieldDescriptor = {
+  name: string;                     // Field name
+  type: string;                     // Type name - standard types are 'i32', 'i64', 'f32', 'f64', 'funcPtr'
+  offset?: number;                  // Optional: byte offset (calculated automatically if not provided)
+};
+
+/**
+ * Standard WebAssembly types
+ */
+export const STANDARD_WASM_TYPES = ['i32', 'i64', 'f32', 'f64', 'funcPtr'];
+
+/**
+ * MemoryArrayAccessor - A flexible class to iterate through arrays in WebAssembly memory
+ * with automatic offset calculation for fields
+ */
+export class MemoryArrayAccessor {
+  private memory: WebAssembly.Memory;
+  private functionTable: WebAssembly.Table;
+  private arrayPtr: number;
+  private count: number;
+  private currentIndex: number = 0;
+  private fields: Required<MemoryFieldDescriptor>[];  // Fields with calculated offsets
+  private elementSize: number;
+  
+  /**
+   * Creates a new accessor for an array in WebAssembly memory
+   * 
+   * @param memory WebAssembly memory containing the array
+   * @param functionTable WebAssembly function table (needed for function pointers)
+   * @param arrayPtr Pointer to the beginning of the array in memory
+   * @param count Number of elements in the array
+   * @param fields Array of field descriptors defining the structure of each element
+   * @param elementSize Optional size of each element in bytes (calculated from fields if not provided)
+   */
+  constructor(
+    memory: WebAssembly.Memory,
+    functionTable: WebAssembly.Table,
+    arrayPtr: number,
+    count: number,
+    fields: MemoryFieldDescriptor[],
+    elementSize?: number
+  ) {
+    this.memory = memory;
+    this.functionTable = functionTable;
+    this.arrayPtr = arrayPtr;
+    this.count = count;
+    
+    // Calculate field offsets if not provided
+    this.fields = this.calculateFieldOffsets(fields);
+    
+    // Calculate the element size based on the fields or use provided size
+    this.elementSize = elementSize || this.calculateElementSize();
+    
+    // Validate inputs
+    if (count < 0) {
+      throw new Error("MemoryArrayAccessor: Array count must be non-negative");
+    }
+    
+    if (arrayPtr < 0 || (count > 0 && arrayPtr + (this.elementSize * count) > memory.buffer.byteLength)) {
+      throw new Error("MemoryArrayAccessor: Array pointer is outside memory bounds");
+    }
+  }
+  
+  /**
+   * Calculate offsets for fields that don't have them specified
+   */
+  private calculateFieldOffsets(
+    fields: MemoryFieldDescriptor[]
+  ): Required<MemoryFieldDescriptor>[] {
+    const result: Required<MemoryFieldDescriptor>[] = [];
+    let currentOffset = 0;
+    
+    for (const field of fields) {
+      const fieldSize = this.getTypeSize(field.type);
+      let offset: number;
+      
+      if (field.offset !== undefined) {
+        // Use provided offset
+        offset = field.offset;
+      } else {
+        // Simply place the field at the current offset
+        offset = currentOffset;
+      }
+      
+      // Add field with calculated offset
+      result.push({
+        name: field.name,
+        type: field.type,
+        offset
+      });
+      
+      // Update current offset for next field
+      currentOffset = offset + fieldSize;
+    }
+    
+    return result;
+  }
+  
+  /**
+   * Calculates the total size of one element based on field descriptors
+   */
+  private calculateElementSize(): number {
+    if (this.fields.length === 0) {
+      throw new Error("MemoryArrayAccessor: No fields defined");
+    }
+    
+    // Find the field with the highest offset + size
+    let maxEnd = 0;
+    
+    for (const field of this.fields) {
+      const fieldSize = this.getTypeSize(field.type);
+      const fieldEnd = field.offset + fieldSize;
+      
+      if (fieldEnd > maxEnd) {
+        maxEnd = fieldEnd;
+      }
+    }
+    
+    return maxEnd;
+  }
+  
+  /**
+   * Gets the size in bytes for a given type
+   */
+  private getTypeSize(type: string): number {
+    switch (type) {
+      case 'i32':
+      case 'f32':
+      case 'funcPtr': // Function pointers are 32-bit indices
+        return 4;
+      case 'i64':
+      case 'f64':
+        return 8;
+      default:
+        // For now, default to 4 bytes for unknown types with a warning
+        console.warn(`MemoryArrayAccessor: Unknown type "${type}", defaulting to 4 bytes`);
+        return 4;
+    }
+  }
+  
+  /**
+   * Returns the calculated element size
+   */
+  getElementSize(): number {
+    return this.elementSize;
+  }
+  
+  /**
+   * Returns the fields with their calculated offsets
+   */
+  getFields(): Required<MemoryFieldDescriptor>[] {
+    return this.fields;
+  }
+  
+  /**
+   * Checks if there are more elements to iterate
+   */
+  hasNext(): boolean {
+    return this.currentIndex < this.count;
+  }
+  
+  /**
+   * Gets the current index in the iteration
+   */
+  getCurrentIndex(): number {
+    return this.currentIndex;
+  }
+  
+  /**
+   * Gets the total count of elements
+   */
+  getCount(): number {
+    return this.count;
+  }
+  
+  /**
+   * Moves to the next element
+   */
+  next(): void {
+    if (this.hasNext()) {
+      this.currentIndex++;
+    }
+  }
+  
+  /**
+   * Resets the iterator to the beginning of the array
+   */
+  reset(): void {
+    this.currentIndex = 0;
+  }
+  
+  /**
+   * Gets the current element's pointer in memory
+   */
+  getCurrentElementPtr(): number {
+    if (!this.hasNext()) {
+      throw new Error("MemoryArrayAccessor: No more elements");
+    }
+    
+    return this.arrayPtr + (this.currentIndex * this.elementSize);
+  }
+  
+  /**
+   * Gets a value from the current element based on a field name
+   */
+  getFieldValue(fieldName: string): any {
+    const field = this.fields.find(f => f.name === fieldName);
+    if (!field) {
+      throw new Error(`MemoryArrayAccessor: Field "${fieldName}" not found`);
+    }
+    
+    const elementPtr = this.getCurrentElementPtr();
+    const fieldPtr = elementPtr + field.offset;
+    const dataView = new DataView(this.memory.buffer);
+    
+    switch (field.type) {
+      case 'i32':
+        return dataView.getInt32(fieldPtr, true);
+      case 'i64':
+        return dataView.getBigInt64(fieldPtr, true);
+      case 'f32':
+        return dataView.getFloat32(fieldPtr, true);
+      case 'f64':
+        return dataView.getFloat64(fieldPtr, true);
+      case 'funcPtr':
+        const funcPtr = dataView.getUint32(fieldPtr, true);
+        // Validate function pointer
+        if (funcPtr >= this.functionTable.length || funcPtr < 0) {
+          throw new Error(`MemoryArrayAccessor: Invalid function pointer ${funcPtr} at index ${this.currentIndex}`);
+        }
+        return funcPtr;
+      default:
+        throw new Error(`MemoryArrayAccessor: Unknown type "${field.type}"`);
+    }
+  }
+  
+  /**
+   * Gets all field values for the current element as an object
+   */
+  getCurrentElement(): Record<string, any> {
+    const result: Record<string, any> = {};
+    
+    for (const field of this.fields) {
+      result[field.name] = this.getFieldValue(field.name);
+    }
+    
+    return result;
+  }
+  
+  /**
+   * Gets all elements as an array of objects
+   */
+  getAllElements(): Record<string, any>[] {
+    const result: Record<string, any>[] = [];
+    this.reset();
+    
+    while (this.hasNext()) {
+      result.push(this.getCurrentElement());
+      this.next();
+    }
+    
+    this.reset();
+    return result;
+  }
+  
+  /**
+   * Gets a specific field value from all elements
+   */
+  getFieldFromAllElements(fieldName: string): any[] {
+    const result: any[] = [];
+    this.reset();
+    
+    while (this.hasNext()) {
+      result.push(this.getFieldValue(fieldName));
+      this.next();
+    }
+    
+    this.reset();
+    return result;
+  }
+  
+  /**
+   * Creates a struct definition for a convenient way to define memory layouts
+   */
+  static createStructDefinition(fields: MemoryFieldDescriptor[]): Required<MemoryFieldDescriptor>[] {
+    let currentOffset = 0;
+    const result: Required<MemoryFieldDescriptor>[] = [];
+    
+    for (const field of fields) {
+      let fieldSize: number;
+      
+      switch (field.type) {
+        case 'i32':
+        case 'f32':
+        case 'funcPtr':
+          fieldSize = 4;
+          break;
+        case 'i64':
+        case 'f64':
+          fieldSize = 8;
+          break;
+        default:
+          console.warn(`Unknown type: ${field.type}, defaulting to 4 bytes`);
+          fieldSize = 4;
+          break;
+      }
+      
+      let offset: number;
+      if (field.offset !== undefined) {
+        offset = field.offset;
+      } else {
+        // Simply place field at current offset
+        offset = currentOffset;
+      }
+      
+      result.push({
+        name: field.name,
+        type: field.type,
+        offset
+      });
+      
+      // Update offset for next field
+      currentOffset = offset + fieldSize;
+    }
+    
+    return result;
+  }
+}
+
+/**
+ * Helper function to calculate struct layout and total size
+ */
+export function calculateStructLayout(
+  fields: MemoryFieldDescriptor[]
+): { fields: Required<MemoryFieldDescriptor>[], size: number } {
+  const layoutFields = MemoryArrayAccessor.createStructDefinition(fields);
+  
+  // Calculate struct size from the last field's offset + size
+  let maxEnd = 0;
+  for (const field of layoutFields) {
+    let fieldSize = 4; // Default size
+    
+    switch (field.type) {
+      case 'i64':
+      case 'f64':
+        fieldSize = 8;
+        break;
+      case 'i32':
+      case 'f32':
+      case 'funcPtr':
+        fieldSize = 4;
+        break;
+    }
+    
+    const fieldEnd = field.offset + fieldSize;
+    if (fieldEnd > maxEnd) {
+      maxEnd = fieldEnd;
+    }
+  }
+  
+  return {
+    fields: layoutFields,
+    size: maxEnd
+  };
+}

--- a/ctowasm/src/modules/pix_and_flix/index.ts
+++ b/ctowasm/src/modules/pix_and_flix/index.ts
@@ -11,6 +11,7 @@ import {
   getExternalFunction,
 } from "~src/modules/util";
 import { StructDataType } from "~src/parser/c-ast/dataTypes";
+import { addCustomJsFunctionToTable } from "~src/modules/jsFunctionUtils";
 
 // the name that this module is imported into wasm by,
 // as well as the include name to use in C program file.
@@ -326,6 +327,316 @@ export class PixAndFlixLibrary extends Module {
         jsFunction: () => {
           getExternalFunction("set_fps", config)();
         },
+      },
+      compose_filter: {
+        parentImportedObject: pixAndFlixLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "pointer",
+              pointeeType: {
+                type: "function",
+                parameters: [
+                  {
+                    type: "pointer",
+                    pointeeType: {
+                      type: "array",
+                      elementDataType: {
+                        type: "array",
+                        elementDataType: {
+                          type: "primary",
+                          primaryDataType: "signed char",
+                        },
+                        numElements: {
+                          type: "IntegerConstant",
+                          value: 4n,
+                          suffix: null,
+                          position: {
+                            start: { line: 0, offset: 0, column: 0 },
+                            end: { line: 0, offset: 0, column: 0 },
+                          },
+                        },
+                      },
+                      numElements: {
+                        type: "IntegerConstant",
+                          value: 400n,
+                          suffix: null,
+                          position: {
+                            start: { line: 0, offset: 0, column: 0 },
+                            end: { line: 0, offset: 0, column: 0 },
+                          },
+                      },
+                    },
+                  },
+                  {
+                    type: "pointer",
+                    pointeeType: {
+                      type: "array",
+                      elementDataType: {
+                        type: "array",
+                        elementDataType: {
+                          type: "primary",
+                          primaryDataType: "signed char",
+                        },
+                        numElements: {
+                          type: "IntegerConstant",
+                          value: 4n,
+                          suffix: null,
+                          position: {
+                            start: { line: 0, offset: 0, column: 0 },
+                            end: { line: 0, offset: 0, column: 0 },
+                          },
+                        },
+                      },
+                      numElements: {
+                        type: "IntegerConstant",
+                        value: 400n,
+                        suffix: null,
+                        position: {
+                          start: { line: 0, offset: 0, column: 0 },
+                          end: { line: 0, offset: 0, column: 0 },
+                        },
+                      },
+                    },
+                  },
+                  {
+                    type: "primary",
+                    primaryDataType: "signed int",
+                  },
+                  {
+                    type: "primary",
+                    primaryDataType: "signed int",
+                  },
+                ],
+                returnType: voidDataType,
+              },
+            },
+            {
+              type: "pointer",
+              pointeeType: {
+                type: "function",
+                parameters: [
+                  {
+                    type: "pointer",
+                    pointeeType: {
+                      type: "array",
+                      elementDataType: {
+                        type: "array",
+                        elementDataType: {
+                          type: "primary",
+                          primaryDataType: "signed char",
+                        },
+                        numElements: {
+                          type: "IntegerConstant",
+                          value: 4n,
+                          suffix: null,
+                          position: {
+                            start: { line: 0, offset: 0, column: 0 },
+                            end: { line: 0, offset: 0, column: 0 },
+                          },
+                        },
+                      },
+                      numElements: {
+                        type: "IntegerConstant",
+                        value: 400n,
+                        suffix: null,
+                        position: {
+                          start: { line: 0, offset: 0, column: 0 },
+                          end: { line: 0, offset: 0, column: 0 },
+                        },
+                      },
+                    },
+                  },
+                  {
+                    type: "pointer",
+                    pointeeType: {
+                      type: "array",
+                      elementDataType: {
+                        type: "array",
+                        elementDataType: {
+                          type: "primary",
+                          primaryDataType: "signed char",
+                        },
+                        numElements: {
+                          type: "IntegerConstant",
+                          value: 4n,
+                          suffix: null,
+                          position: {
+                            start: { line: 0, offset: 0, column: 0 },
+                            end: { line: 0, offset: 0, column: 0 },
+                          },
+                        },
+                      },
+                      numElements: {
+                        type: "IntegerConstant",
+                        value: 400n,
+                        suffix: null,
+                        position: {
+                          start: { line: 0, offset: 0, column: 0 },
+                          end: { line: 0, offset: 0, column: 0 },
+                        },
+                      },
+                    },
+                  },
+                  {
+                    type: "primary",
+                    primaryDataType: "signed int",
+                  },
+                  {
+                    type: "primary",
+                    primaryDataType: "signed int",
+                  },
+                ],
+                returnType: voidDataType,
+              },
+            },
+          ],
+          returnType: {
+            type: "pointer",
+            pointeeType: {
+              type: "function",
+              parameters: [
+                {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "array",
+                    elementDataType: {
+                      type: "array",
+                      elementDataType: {
+                        type: "primary",
+                        primaryDataType: "signed char",
+                      },
+                      numElements: {
+                        type: "IntegerConstant",
+                        value: 4n,
+                        suffix: null,
+                        position: {
+                          start: { line: 0, offset: 0, column: 0 },
+                          end: { line: 0, offset: 0, column: 0 },
+                        },
+                      },
+                    },
+                    numElements: {
+                      type: "IntegerConstant",
+                      value: 400n,
+                      suffix: null,
+                      position: {
+                        start: { line: 0, offset: 0, column: 0 },
+                        end: { line: 0, offset: 0, column: 0 },
+                      },
+                    },
+                  },
+                },
+                {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "array",
+                    elementDataType: {
+                      type: "array",
+                      elementDataType: {
+                        type: "primary",
+                        primaryDataType: "signed char",
+                      },
+                      numElements: {
+                        type: "IntegerConstant",
+                        value: 4n,
+                        suffix: null,
+                        position: {
+                          start: { line: 0, offset: 0, column: 0 },
+                          end: { line: 0, offset: 0, column: 0 },
+                        },
+                      },
+                    },
+                    numElements: {
+                      type: "IntegerConstant",
+                      value: 400n,
+                      suffix: null,
+                      position: {
+                        start: { line: 0, offset: 0, column: 0 },
+                        end: { line: 0, offset: 0, column: 0 },
+                      },
+                    },
+                  },
+                },
+                {
+                  type: "primary",
+                  primaryDataType: "signed int",
+                },
+                {
+                  type: "primary",
+                  primaryDataType: "signed int",
+                },
+              ],
+              returnType: voidDataType,
+            },
+          },
+        },
+        jsFunction: (filter1: number, filter2: number) => {
+          const composedFilterFunction = (srcPtr: number, destPtr: number, height: number, width: number) => {
+            const memSize = height * width * 4;
+            
+            const intermediatePtr = mallocFunction({
+              memory,
+              sharedWasmGlobalVariables,
+              freeList: this.freeList,
+              allocatedBlocks: this.allocatedBlocks,
+              bytesRequested: memSize,
+            });
+            
+            const intermediateBuf = new Uint8Array(memory.buffer, intermediatePtr, memSize);
+            intermediateBuf.fill(0);
+                
+            const args1: StackFrameArg[] = [
+              { value: BigInt(srcPtr), type: "unsigned int" },
+              { value: BigInt(intermediatePtr), type: "unsigned int" },
+              { value: BigInt(height), type: "unsigned int" },
+              { value: BigInt(width), type: "unsigned int" }
+            ];
+            
+            wrapFunctionPtrCall(
+              memory,
+              functionTable,
+              filter1,
+              sharedWasmGlobalVariables,
+              args1,
+              []
+            );
+            
+            const args2: StackFrameArg[] = [
+              { value: BigInt(intermediatePtr), type: "unsigned int" },
+              { value: BigInt(destPtr), type: "unsigned int" },
+              { value: BigInt(height), type: "unsigned int" },
+              { value: BigInt(width), type: "unsigned int" }
+            ];
+            
+            wrapFunctionPtrCall(
+              memory,
+              functionTable,
+              filter2,
+              sharedWasmGlobalVariables,
+              args2,
+              []
+            );
+
+            freeFunction({
+              address: intermediatePtr,
+              freeList: this.freeList,
+              allocatedBlocks: this.allocatedBlocks,
+            });
+          }
+          
+          const composedFuncPtr = addCustomJsFunctionToTable(
+            composedFilterFunction,
+            ["i32", "i32", "i32", "i32"], 
+            null,
+            functionTable,
+            memory,
+            sharedWasmGlobalVariables
+          );
+
+          return composedFuncPtr;
+        }
       },
     };
   }

--- a/ctowasm/src/modules/plotly/index.ts
+++ b/ctowasm/src/modules/plotly/index.ts
@@ -1,0 +1,93 @@
+import { ModulesGlobalConfig, SharedWasmGlobalVariables } from "~src/modules";
+import { voidDataType } from "~src/modules/constants";
+import wrapFunctionPtrCall from "~src/modules/stackFrameUtils";
+import { Module, ModuleFunction, StackFrameArg } from "~src/modules/types";
+import {
+  getExternalFunction,
+} from "~src/modules/util";
+import { StructDataType } from "~src/parser/c-ast/dataTypes";
+
+export const plotlyLibraryModuleImportName = "plotly";
+
+export class PlotlyLibraryModule extends Module {
+  moduleDeclaredStructs: StructDataType[];
+  moduleFunctions: Record<string, ModuleFunction>;
+  sharedWasmGlobalVariables: SharedWasmGlobalVariables;
+
+  constructor(
+    memory: WebAssembly.Memory,
+    functionTable: WebAssembly.Table,
+    config: ModulesGlobalConfig,
+    sharedWasmGlobalVariables: SharedWasmGlobalVariables,
+  ) {
+    super(memory, functionTable, config, sharedWasmGlobalVariables);
+    this.sharedWasmGlobalVariables = sharedWasmGlobalVariables;
+    this.moduleDeclaredStructs = [];
+    this.moduleFunctions = {
+      draw_sound_2d: {
+        parentImportedObject: plotlyLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "struct",
+              tag: "Sound",
+              fields: [
+                {
+                  tag: "wave",
+                  dataType: {
+                    type: "pointer",
+                    pointeeType: {
+                      type: "function",
+                      parameters: [
+                        {
+                          type: "primary",
+                          primaryDataType: "double",
+                        }
+                      ],
+                      returnType: {
+                        type: "primary",
+                        primaryDataType: "double"
+                      }
+                    }
+                  },
+                  isConst: false
+                },
+                {
+                  tag: "duration",
+                  dataType: {
+                    type: "primary",
+                    primaryDataType: "double"
+                  },
+                  isConst: false
+                }
+              ]
+            },
+          ],
+          returnType: voidDataType
+        },
+        jsFunction: (wave: number, duration: number) => {
+          const waveJS = (t: number) => {
+            const stackFrameArgs: StackFrameArg[] = [
+              {
+                value: Number(t),
+                type: "double"
+              },
+            ];
+      
+            const returnValues = wrapFunctionPtrCall(
+              memory,
+              functionTable,
+              wave,
+              sharedWasmGlobalVariables,
+              stackFrameArgs,
+              ["double"],
+            );
+            return returnValues[0];
+          };
+          getExternalFunction("draw_sound_2d", config)([waveJS, duration]);
+        }
+      },
+    };
+  }
+}

--- a/ctowasm/src/modules/plotly/types.ts
+++ b/ctowasm/src/modules/plotly/types.ts
@@ -1,0 +1,10 @@
+// export type Color = [r: number, g: number, b: number, t: number];
+
+// export class Point {
+//   constructor(
+//     public readonly x: number,
+//     public readonly y: number,
+//     public readonly z: number,
+//     public readonly color: Color
+//   ) {}
+// }

--- a/ctowasm/src/modules/sound/index.ts
+++ b/ctowasm/src/modules/sound/index.ts
@@ -1,0 +1,1422 @@
+import { ModulesGlobalConfig, SharedWasmGlobalVariables } from "~src/modules";
+import { voidDataType } from "~src/modules/constants";
+import wrapFunctionPtrCall from "~src/modules/stackFrameUtils";
+import { Module, ModuleFunction, StackFrameArg } from "~src/modules/types";
+import {
+  extractCStyleStringFromMemory,
+  getExternalFunction,
+} from "~src/modules/util";
+import { StructDataType } from "~src/parser/c-ast/dataTypes";
+import { addCustomJsFunctionToTable } from "~src/modules/jsFunctionUtils";
+import { MemoryArrayAccessor } from "~src/modules/memoryArrayAccessorUtils";
+
+export const soundLibraryModuleImportName = "sound";
+
+export class SoundLibraryModule extends Module {
+  moduleDeclaredStructs: StructDataType[];
+  moduleFunctions: Record<string, ModuleFunction>;
+  sharedWasmGlobalVariables: SharedWasmGlobalVariables;
+
+  constructor(
+    memory: WebAssembly.Memory,
+    functionTable: WebAssembly.Table,
+    config: ModulesGlobalConfig,
+    sharedWasmGlobalVariables: SharedWasmGlobalVariables,
+  ) {
+    super(memory, functionTable, config, sharedWasmGlobalVariables);
+    this.sharedWasmGlobalVariables = sharedWasmGlobalVariables;
+    this.moduleDeclaredStructs = [];
+    this.moduleFunctions = {
+      play_wave: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+              {
+                  type: "pointer",
+                  pointeeType: {
+                      type: "function",
+                      parameters: [
+                          {
+                              type: "primary",
+                              primaryDataType: "double",
+                          }
+                      ],
+                      returnType: {
+                          type: "primary",
+                          primaryDataType: "double",
+                      }
+                  }
+              },
+              {
+                  type: "primary",
+                  primaryDataType: "double",
+              }
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (wave: number, duration: number) => {
+          const waveJS = (t : number) => {
+            const stackFrameArgs: StackFrameArg[] = [
+              {
+                  value: Number(t),
+                  type: "double"
+              },
+            ]
+
+            const returnValues = wrapFunctionPtrCall(
+              memory,
+              functionTable,
+              wave,
+              sharedWasmGlobalVariables,
+              stackFrameArgs,
+              ["double"],
+            );
+
+            return returnValues[0];
+          }
+          getExternalFunction("play_wave", config)(waveJS, duration);
+          return [wave, duration];
+        },
+      },
+      play: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "struct",
+              tag: "Sound",
+              fields: [
+                {
+                  tag: "wave",
+                  dataType: {
+                    type: "pointer",
+                    pointeeType: {
+                      type: "function",
+                      parameters: [
+                        {
+                          type: "primary",
+                          primaryDataType: "double",
+                        }
+                      ],
+                      returnType: {
+                        type: "primary",
+                        primaryDataType: "double"
+                      }
+                    }
+                  },
+                  isConst: false
+                },
+                {
+                  tag: "duration",
+                  dataType: {
+                    type: "primary",
+                    primaryDataType: "double"
+                  },
+                  isConst: false
+                }
+              ]
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (wave: number, duration: number) => {
+          const waveJS = (t: number) => {
+            const stackFrameArgs: StackFrameArg[] = [
+              {
+                value: Number(t),
+                type: "double"
+              },
+            ];
+      
+            const returnValues = wrapFunctionPtrCall(
+              memory,
+              functionTable,
+              wave,
+              sharedWasmGlobalVariables,
+              stackFrameArgs,
+              ["double"],
+            );
+            return returnValues[0];
+          };
+          getExternalFunction("play", config)([waveJS, duration]);
+          return [wave, duration];
+        }
+      },
+      play_in_tab: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "struct",
+              tag: "Sound",
+              fields: [
+                {
+                  tag: "wave",
+                  dataType: {
+                    type: "pointer",
+                    pointeeType: {
+                      type: "function",
+                      parameters: [
+                        {
+                          type: "primary",
+                          primaryDataType: "double",
+                        }
+                      ],
+                      returnType: {
+                        type: "primary",
+                        primaryDataType: "double"
+                      }
+                    }
+                  },
+                  isConst: false
+                },
+                {
+                  tag: "duration",
+                  dataType: {
+                    type: "primary",
+                    primaryDataType: "double"
+                  },
+                  isConst: false
+                }
+              ]
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (wave: number, duration: number) => {
+          const waveJS = (t: number) => {
+            const stackFrameArgs: StackFrameArg[] = [
+              {
+                value: Number(t),
+                type: "double"
+              },
+            ];
+      
+            const returnValues = wrapFunctionPtrCall(
+              memory,
+              functionTable,
+              wave,
+              sharedWasmGlobalVariables,
+              stackFrameArgs,
+              ["double"],
+            );
+            return returnValues[0];
+          };
+          getExternalFunction("play_in_tab", config)([waveJS, duration]);
+          return [wave, duration];
+        }
+      },
+      make_sound: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "pointer",
+              pointeeType: {
+                type: "function",
+                parameters: [
+                  {
+                    type: "primary",
+                    primaryDataType: "double"
+                  }
+                ],
+                returnType: {
+                  type: "primary",
+                  primaryDataType: "double"
+              }
+              }
+          },
+            {
+              type: "primary",
+              primaryDataType: "double"
+            }
+          ],
+          returnType: {
+              type: "struct",
+              tag: "Sound",
+              fields: [
+                  {
+                      tag: "wave",
+                      dataType: {
+                          type: "pointer",
+                          pointeeType: {
+                              type: "function",
+                              parameters: [
+                                  {
+                                      type: "primary",
+                                      primaryDataType: "double"
+                                  }
+                              ],
+                              returnType: {
+                                  type: "primary",
+                                  primaryDataType: "double"
+                              }
+                          }
+                      },
+                      isConst: false
+                  },
+                  {
+                      tag: "duration",
+                      dataType: {
+                          type: "primary",
+                          primaryDataType: "double"
+                      },
+                      isConst: false
+                  }
+              ]
+          }
+        },
+        jsFunction: (funcPtr: number, duration: number)=>{
+          return [funcPtr, duration];
+        }
+      },
+      cello: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "signed int", 
+            },
+            {
+              type: "primary",
+              primaryDataType: "double", 
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (note: number, duration: number) => {
+          const sound = getExternalFunction("cello", config)(note, duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      bell: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "signed int", 
+            },
+            {
+              type: "primary",
+              primaryDataType: "double", 
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (note: number, duration: number) => {
+          const sound = getExternalFunction("bell", config)(note, duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      trombone: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "signed int", 
+            },
+            {
+              type: "primary",
+              primaryDataType: "double", 
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (note: number, duration: number) => {
+          const sound = getExternalFunction("trombone", config)(note, duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      violin: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "signed int", 
+            },
+            {
+              type: "primary",
+              primaryDataType: "double", 
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (note: number, duration: number) => {
+          const sound = getExternalFunction("violin", config)(note, duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },    
+      piano: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "signed int", 
+            },
+            {
+              type: "primary",
+              primaryDataType: "double", 
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (note: number, duration: number) => {
+          const sound = getExternalFunction("piano", config)(note, duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      sawtooth_sound: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "double", // freq parameter as double
+            },
+            {
+              type: "primary",
+              primaryDataType: "double", // duration parameter
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (freq: number, duration: number) => {
+          const sound = getExternalFunction("sawtooth_sound", config)(freq, duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      triangle_sound: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "double", // freq parameter as double
+            },
+            {
+              type: "primary",
+              primaryDataType: "double", // duration parameter
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (freq: number, duration: number) => {
+          const sound = getExternalFunction("triangle_sound", config)(freq, duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      sine_sound: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "double", // freq parameter as double
+            },
+            {
+              type: "primary",
+              primaryDataType: "double", // duration parameter
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (freq: number, duration: number) => {
+          const sound = getExternalFunction("sine_sound", config)(freq, duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      square_sound: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "double", // freq parameter as double
+            },
+            {
+              type: "primary",
+              primaryDataType: "double", // duration parameter
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (freq: number, duration: number) => {
+          const sound = getExternalFunction("square_sound", config)(freq, duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      noise_sound: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "double", // duration parameter only
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (duration: number) => {
+          const sound = getExternalFunction("noise_sound", config)(duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      silence_sound: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "double",
+            },
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          },
+        },
+        jsFunction: (duration: number) => {
+          const sound = getExternalFunction("silence_sound", config)(duration);
+          const wave = addCustomJsFunctionToTable(
+            sound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+          return [wave, sound[1]];
+        }
+      },
+      letter_name_to_midi_note: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "pointer",
+              pointeeType: {
+                type: "primary",
+                primaryDataType: "signed char",
+              },
+            },
+          ],
+          returnType: {
+            type: "primary",
+            primaryDataType: "signed int"
+          },
+        },
+        jsFunction: (strAddress: number) => {
+          const noteStr = extractCStyleStringFromMemory(memory.buffer, strAddress);
+          return getExternalFunction("letter_name_to_midi_note", config)(noteStr);
+        }
+      },
+      letter_name_to_frequency: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "pointer",
+              pointeeType: {
+                type: "primary",
+                primaryDataType: "signed char",
+              },
+            },
+          ],
+          returnType: {
+            type: "primary",
+            primaryDataType: "double"
+          },
+        },
+        jsFunction: (strAddress: number) => {
+          const noteStr = extractCStyleStringFromMemory(memory.buffer, strAddress);
+          return getExternalFunction("letter_name_to_frequency", config)(noteStr);
+        }
+      },
+      midi_note_to_frequency: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "primary",
+              primaryDataType: "signed int", 
+            },
+          ],
+          returnType: {
+            type: "primary",
+            primaryDataType: "double" 
+          },
+        },
+        jsFunction: (midiNote: number) => {
+          return getExternalFunction("midi_note_to_frequency", config)(midiNote);
+        }
+      },
+      stop: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [],
+          returnType: voidDataType,
+        },
+        jsFunction: () => {
+          getExternalFunction("stop", config)();
+        }
+      },
+      consecutively: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "pointer",
+              pointeeType: {
+                type: "struct",
+                tag: "Sound",
+                fields: [
+                  {
+                    tag: "wave",
+                    dataType: {
+                      type: "pointer",
+                      pointeeType: {
+                        type: "function",
+                        parameters: [
+                          {
+                            type: "primary",
+                            primaryDataType: "double",
+                          }
+                        ],
+                        returnType: {
+                          type: "primary",
+                          primaryDataType: "double"
+                        }
+                      }
+                    },
+                    isConst: false
+                  },
+                  {
+                    tag: "duration",
+                    dataType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    },
+                    isConst: false
+                  }
+                ]
+              }
+            },
+            {
+              type: "primary",
+              primaryDataType: "signed int",
+            }
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          } 
+        },
+        jsFunction: (soundArrayPtr: number, count: number) => {
+          const soundFields = [
+            { name: 'wave', type: 'funcPtr' },
+            { name: 'duration', type: 'f64' }
+          ];
+          
+          const soundAccessor = new MemoryArrayAccessor(
+            memory,
+            functionTable,
+            soundArrayPtr,
+            count,
+            soundFields
+          );
+
+          const sounds = [];
+          
+          while (soundAccessor.hasNext()) {
+            const element = soundAccessor.getCurrentElement();
+            const wavePtr = element.wave;
+            const duration = element.duration;
+
+            const waveJS = (t: number) => {
+              const stackFrameArgs: StackFrameArg[] = [
+                { value: Number(t), type: "double" }
+              ];
+              
+              const returnValues = wrapFunctionPtrCall(
+                memory,
+                functionTable,
+                wavePtr,
+                sharedWasmGlobalVariables,
+                stackFrameArgs,
+                ["double"]
+              );
+              
+              return returnValues[0];
+            };
+            
+            sounds.push([waveJS, duration]);
+            
+            soundAccessor.next();
+          }
+
+          // Convert the array of sounds to a List (as defined in sound in modules)
+          let soundList = null;
+          
+          // Build the list in reverse order (since we're prepending)
+          for (let i = sounds.length - 1; i >= 0; i--) {
+            soundList = [sounds[i], soundList];
+          }
+          
+          const resultSound = getExternalFunction("consecutively", config)(soundList);
+          
+          const newWavePtr = addCustomJsFunctionToTable(
+            resultSound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+
+          return [newWavePtr, resultSound[1]];
+        }
+      },
+      simultaneously: {
+        parentImportedObject: soundLibraryModuleImportName,
+        functionType: {
+          type: "function",
+          parameters: [
+            {
+              type: "pointer",
+              pointeeType: {
+                type: "struct",
+                tag: "Sound",
+                fields: [
+                  {
+                    tag: "wave",
+                    dataType: {
+                      type: "pointer",
+                      pointeeType: {
+                        type: "function",
+                        parameters: [
+                          {
+                            type: "primary",
+                            primaryDataType: "double",
+                          }
+                        ],
+                        returnType: {
+                          type: "primary",
+                          primaryDataType: "double"
+                        }
+                      }
+                    },
+                    isConst: false
+                  },
+                  {
+                    tag: "duration",
+                    dataType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    },
+                    isConst: false
+                  }
+                ]
+              }
+            },
+            {
+              type: "primary",
+              primaryDataType: "signed int",
+            }
+          ],
+          returnType: {
+            type: "struct",
+            tag: "Sound",
+            fields: [
+              {
+                tag: "wave",
+                dataType: {
+                  type: "pointer",
+                  pointeeType: {
+                    type: "function",
+                    parameters: [
+                      {
+                        type: "primary",
+                        primaryDataType: "double",
+                      }
+                    ],
+                    returnType: {
+                      type: "primary",
+                      primaryDataType: "double"
+                    }
+                  }
+                },
+                isConst: false
+              },
+              {
+                tag: "duration",
+                dataType: {
+                  type: "primary",
+                  primaryDataType: "double"
+                },
+                isConst: false
+              }
+            ]
+          } 
+        },
+        jsFunction: (soundArrayPtr: number, count: number) => {      
+          const soundFields = [
+            { name: 'wave', type: 'funcPtr' },
+            { name: 'duration', type: 'f64' }
+          ];
+          
+          const soundAccessor = new MemoryArrayAccessor(
+            memory,
+            functionTable,
+            soundArrayPtr,
+            count,
+            soundFields
+          );
+      
+          const sounds = [];
+          
+          while (soundAccessor.hasNext()) {
+            const element = soundAccessor.getCurrentElement();
+            const wavePtr = element.wave;
+            const duration = element.duration;
+      
+            const waveJS = (t: number) => {
+              const stackFrameArgs: StackFrameArg[] = [
+                { value: Number(t), type: "double" }
+              ];
+              
+              const returnValues = wrapFunctionPtrCall(
+                memory,
+                functionTable,
+                wavePtr,
+                sharedWasmGlobalVariables,
+                stackFrameArgs,
+                ["double"]
+              );
+              
+              return returnValues[0];
+            };
+            
+            sounds.push([waveJS, duration]);
+            
+            soundAccessor.next();
+          }
+      
+          // Convert the array of sounds to a List (as defined in sound in modules)
+          let soundList = null;
+          
+          // Build the list in reverse order (since we're prepending)
+          for (let i = sounds.length - 1; i >= 0; i--) {
+            soundList = [sounds[i], soundList];
+          }
+          
+          const resultSound = getExternalFunction("simultaneously", config)(soundList);
+          
+          const newWavePtr = addCustomJsFunctionToTable(
+            resultSound[0],
+            ["f64"],
+            "f64",
+            functionTable,
+            memory,
+            this.sharedWasmGlobalVariables
+          );
+      
+          return [newWavePtr, resultSound[1]];
+        }
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Adding of JavaScript function into the WASM table with custom signatures (jsFunctionUtils.ts)

Provides a utility to register any JavaScript function in a WebAssembly function table at runtime.

### Example Usage

```ts
const table = wasmInstance.exports.__indirect_function_table as WebAssembly.Table;
const memory = wasmInstance.exports.memory as WebAssembly.Memory;

const callbackIndex = addCustomJsFunctionToTable(
  (x: number, n: number) => Math.floor(x * n), 
  ["f64", "i32"],   // parameter types
  "i32",            // return type
  table,
  memory,
  sharedWasmGlobalVariables
);

// Now inside your Wasm you can invoke it indirectly
```

## Memory and Array Accessors for WebAssembly Linear Memory (memoryArrayAccessorUtils.ts)

Provides a `MemoryArrayAccessor` class and helper functions to define and manipulate arrays of structured records in Wasm linear memory—automatically computing field offsets, iterating elements, and reading/writing primitive (`i32`, `i64`, `f32`, `f64`) and function-pointer fields directly via `DataView`.

### Example Usage

```ts
import {
  MemoryArrayAccessor,
  calculateStructLayout,
  MemoryFieldDescriptor
} from "./memoryArrayAccessorUtils";

// 1. Define the “struct” layout for each element:
const rawFields: MemoryFieldDescriptor[] = [
  { name: "id",       type: "i32"     }, // 4 bytes
  { name: "score",    type: "f64"     }, // 8 bytes
  { name: "callback", type: "funcPtr" }  // 4 bytes
];

// 2. (Optional) Compute automatic offsets and element size:
const { fields: layoutFields, size: elementSize } =
  calculateStructLayout(rawFields);

// 3. Instantiate your accessor:
//    - `memory`   : WebAssembly.Memory
//    - `table`    : WebAssembly.Table (for funcPtr fields)
//    - `arrayPtr` : byte offset where your array begins in Wasm memory
//    - `count`    : number of elements in the array
const accessor = new MemoryArrayAccessor(
  memory,
  table,
  /* arrayPtr= */ 0,
  /* count= */ 10,
  layoutFields,
  elementSize
);

// 4. Inspect metadata:
console.log("Element size:", accessor.getElementSize()); 
// e.g. 16

console.log("Fields & offsets:", accessor.getFields());
// e.g. [
//   { name: "id", type: "i32", offset: 0 },
//   { name: "score", type: "f64", offset: 4 },
//   { name: "callback", type: "funcPtr", offset: 12 }
// ]

// 5. Iterate through elements one by one:
while (accessor.hasNext()) {
  const id       = accessor.getFieldValue("id");
  const score    = accessor.getFieldValue("score");
  const callback = accessor.getFieldValue("callback");
  console.log({ id, score, callback });
  accessor.next();
}

// 6. Reset and pull all elements at once:
accessor.reset();
const allElements = accessor.getAllElements();
console.log("All elements:", allElements);

// 7. Extract one field across the entire array:
const allIds = accessor.getFieldFromAllElements("id");
console.log("All IDs:", allIds);
```

## pix_n_flix

Added functions:
- compose_filter

## sound

Added functions:
- stop
- play_wave
- play_in_tab
- play
- make_sound
- midi_note_to_frequency
- letter_name_to_frequency
- letter_name_to_midi_note
- simultaneously
- consecutively
- bell
- trombone
- violin
- piano
- cello
- square_sound
- triangle_sound
- sawtooth_sound
- sine_sound
- silence_sound
- noise_sound

Note: 
Instead of taking in a linked-list (list defined in Modules), simultaneously and consecutively takes in a C-style array containing elements of struct Sound, and an integer size of array.

## plotly

Added functions:
- draw_sound_2d